### PR TITLE
feat: made raw_tif_glob redundant for simplicity

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -10,7 +10,6 @@ targets:
 
 import:
   raw_tif_pattern: "{prefix}_Blaze[{tilex} x {tiley}]_C{channel}_xyz-Table Z{zslice}.ome.tif"
-  raw_tif_glob: "{prefix}_Blaze[[]{tilex} x {tiley}[]]_C{channel}_xyz-Table Z{zslice}.ome.tif"
   intensity_rescaling: 0.5 #raw images seem to be at the upper end of uint16 (over-saturated) -- causes wrapping issues when adjusting with flatfield correction etc. this rescales the raw data as it imports it..
 
 

--- a/workflow/rules/import.smk
+++ b/workflow/rules/import.smk
@@ -38,7 +38,7 @@ rule raw_to_metadata:
     input:
         ome_dir=rules.get_dataset.output.ome_dir,
     params:
-        in_tif_glob=lambda wildcards, input: os.path.join(
+        in_tif_pattern=lambda wildcards, input: os.path.join(
             input.ome_dir,
             config["import"]["raw_tif_pattern"],
         ),
@@ -85,9 +85,9 @@ rule tif_to_zarr:
         ome_dir=rules.get_dataset.output.ome_dir,
         metadata_json=rules.raw_to_metadata.output.metadata_json,
     params:
-        in_tif_glob=lambda wildcards, input: os.path.join(
+        in_tif_pattern=lambda wildcards, input: os.path.join(
             input.ome_dir,
-            config["import"]["raw_tif_glob"],
+            config["import"]["raw_tif_pattern"],
         ),
         intensity_rescaling=config["import"]["intensity_rescaling"],
     output:

--- a/workflow/scripts/raw_to_metadata.py
+++ b/workflow/scripts/raw_to_metadata.py
@@ -5,10 +5,10 @@ import re
 from itertools import product
 from snakemake.io import glob_wildcards
 
-in_tif_glob = snakemake.params.in_tif_glob
+in_tif_pattern = snakemake.params.in_tif_pattern
 
 #parse the filenames to get number of channels, tiles etc..
-prefix, tilex, tiley, channel, zslice = glob_wildcards(in_tif_glob)
+prefix, tilex, tiley, channel, zslice = glob_wildcards(in_tif_pattern)
 
 tiles_x = sorted(list(set(tilex)))
 tiles_y = sorted(list(set(tiley)))
@@ -17,7 +17,7 @@ zslices = sorted(list(set(zslice)))
 prefixes = sorted(list(set(prefix)))
 
 #read in series metadata from first file
-in_tif = in_tif_glob.format(tilex=tiles_x[0],tiley=tiles_y[0],prefix=prefixes[0],channel=channels[0],zslice=zslices[0])
+in_tif = in_tif_pattern.format(tilex=tiles_x[0],tiley=tiles_y[0],prefix=prefixes[0],channel=channels[0],zslice=zslices[0])
 
 raw_tif = tifffile.TiffFile(in_tif)
 

--- a/workflow/scripts/tif_to_zarr.py
+++ b/workflow/scripts/tif_to_zarr.py
@@ -5,11 +5,25 @@ import dask.array.image
 from itertools import product
 from dask.diagnostics import ProgressBar
 
-in_tif_glob = snakemake.params.in_tif_glob
+def replace_square_brackets(pattern):
+    """replace all [ and ] in the string (have to use 
+    intermediate variable to avoid conflicts)"""
+    pattern = pattern.replace('[','##LEFTBRACKET##')
+    pattern = pattern.replace(']','##RIGHTBRACKET##')
+    pattern = pattern.replace('##LEFTBRACKET##','[[]')
+    pattern = pattern.replace('##RIGHTBRACKET##','[]]')
+    return pattern
 
-#create function handle to tifffile.imread that sets key=0
+
 def single_imread(*args):
+    """create function handle to tifffile.imread 
+    that sets key=0"""
     return tifffile.imread(*args,key=0)
+
+
+#use tif pattern but replace the [ and ] with [[] and []] so glob doesn't choke
+in_tif_glob = replace_square_brackets(str(snakemake.params.in_tif_pattern))
+
 
 #read metadata json
 with open(snakemake.input.metadata_json) as fp:


### PR DESCRIPTION
replaced square brackets to make the extra config variable definition of raw_tif_glob redundant