### PR TITLE
Tune-up chunking

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -41,10 +41,10 @@ bigstitcher:
       phase_corr: "Phase Correlation"
       optical_flow: "Lucas-Kanade" 
   filter_pairwise_shifts:
-    enabled: 1
+    enabled: 0
     min_r: 0.7
   global_optimization:
-    enabled: 1
+    enabled: 0
     strategy: two_round
     strategies:
       one_round: "One-Round"

--- a/config/config.yml
+++ b/config/config.yml
@@ -41,10 +41,10 @@ bigstitcher:
       phase_corr: "Phase Correlation"
       optical_flow: "Lucas-Kanade" 
   filter_pairwise_shifts:
-    enabled: 0
+    enabled: 1
     min_r: 0.7
   global_optimization:
-    enabled: 0
+    enabled: 1
     strategy: two_round
     strategies:
       one_round: "One-Round"
@@ -66,9 +66,9 @@ ome_zarr:
   desc: stitchedflatcorr
   max_downsampling_layers: 5 # e.g. 4 levels: { 0: orig, 1: ds2, 2: ds4, 3: ds8, 4: ds16}
   rechunk_size: #z, y, x 
-    - 256 
-    - 256
-    - 256
+    - 1 
+    - 4096
+    - 4096
   scaling_method: 'local_mean' #can be nearest, gaussian, local_mean, zoom (zoom uses spline interp)
  
   omero_metadata:

--- a/config/config.yml
+++ b/config/config.yml
@@ -57,10 +57,10 @@ bigstitcher:
     downsampling: 1
     block_size_x: 256 # for storage
     block_size_y: 256
-    block_size_z: 256
+    block_size_z: 1
     block_size_factor_x: 1 #e.g. 2 will use 2*block_size for computation
     block_size_factor_y: 1
-    block_size_factor_z: 1
+    block_size_factor_z: 256
 
 ome_zarr:
   desc: stitchedflatcorr
@@ -76,7 +76,11 @@ ome_zarr:
       default_color: 'FFFFFF'
       color_mapping:
         autof: 'FFFFFF'
+        AutoF: 'FFFFFF'
         abeta: '00FF00'
+        Abeta: '00FF00'
+        PI: 'FFFFFF'
+        AlphaSynuclein: '00FF00'
       defaults:
         active: True
         coefficient: 1.0

--- a/config/config.yml
+++ b/config/config.yml
@@ -55,20 +55,20 @@ bigstitcher:
 
   fuse_dataset:
     downsampling: 1
-    block_size_x: 4096 # for storage
-    block_size_y: 4096
-    block_size_z: 1
-    block_size_factor_x: 2 #e.g. 2 will use 2*block_size for computation
-    block_size_factor_y: 2
+    block_size_x: 256 # for storage
+    block_size_y: 256
+    block_size_z: 256
+    block_size_factor_x: 1 #e.g. 2 will use 2*block_size for computation
+    block_size_factor_y: 1
     block_size_factor_z: 1
 
 ome_zarr:
   desc: stitchedflatcorr
   max_downsampling_layers: 5 # e.g. 4 levels: { 0: orig, 1: ds2, 2: ds4, 3: ds8, 4: ds16}
-  rechunk_size: #z, y, x
-    - 1 
-    - 4096
-    - 4096
+  rechunk_size: #z, y, x 
+    - 256 
+    - 256
+    - 256
   scaling_method: 'local_mean' #can be nearest, gaussian, local_mean, zoom (zoom uses spline interp)
  
   omero_metadata:

--- a/spimprep_run
+++ b/spimprep_run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if ! command -v singularity >/dev/null 2>&1; then
+    echo "Error: 'singularity' is not installed or not in the PATH." >&2
+    exit 1
+fi
+
+container='docker://khanlab/spimprep-deps:main'
+unset SNAKEMAKE_PROFILE
+singularity exec ${container} snakemake --config --set-resources bigstitcher:mem_mb=30000 fuse_dataset:mem_mb=30000 -pr $@
+

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -33,7 +33,7 @@ rule all:
     input:
         get_all_targets(),
         get_bids_toplevel_targets(),
-        get_qc_targets(),
+    #        get_qc_targets(), #need to skip this if using prestitched
     localrule: True
 
 

--- a/workflow/rules/bigstitcher.smk
+++ b/workflow/rules/bigstitcher.smk
@@ -40,6 +40,7 @@ rule zarr_to_bdv:
             )
             / "dataset.xml"
         ),
+        chunks=(1,1,32,32,32)
     output:
         bdv_n5=temp(
             directory(

--- a/workflow/rules/bigstitcher.smk
+++ b/workflow/rules/bigstitcher.smk
@@ -40,7 +40,7 @@ rule zarr_to_bdv:
             )
             / "dataset.xml"
         ),
-        chunks=(1,1,32,32,32)
+        chunks=(32,32,32) #the previous default was 1 x Nx x Ny (Nx Ny were full tile size!)
     output:
         bdv_n5=temp(
             directory(

--- a/workflow/rules/bigstitcher.smk
+++ b/workflow/rules/bigstitcher.smk
@@ -40,7 +40,6 @@ rule zarr_to_bdv:
             )
             / "dataset.xml"
         ),
-        chunks=(128,256,256) #the previous default was 1 x Nx x Ny (Nx Ny were full tile size!)
     output:
         bdv_n5=temp(
             directory(
@@ -159,7 +158,7 @@ rule bigstitcher:
         "cp {input.dataset_xml} {output.dataset_xml} && "
         " {params.fiji_launcher_cmd} && "
         " echo ' -macro {input.ijm} \"{params.macro_args}\"' >> {output.launcher} "
-        " && {output.launcher} &> {log} && {params.rm_old_xml}"
+        " && {output.launcher} |& tee {log} && {params.rm_old_xml}"
 
 
 rule fuse_dataset:
@@ -246,7 +245,7 @@ rule fuse_dataset:
     shell:
         " {params.fiji_launcher_cmd} && "
         " echo ' -macro {input.ijm} \"{params.macro_args}\"' >> {output.launcher} "
-        " && {output.launcher} &> {log}"
+        " && {output.launcher} |& tee {log}"
 
 
 rule fuse_dataset_spark:

--- a/workflow/rules/bigstitcher.smk
+++ b/workflow/rules/bigstitcher.smk
@@ -40,7 +40,7 @@ rule zarr_to_bdv:
             )
             / "dataset.xml"
         ),
-        chunks=(32,32,32) #the previous default was 1 x Nx x Ny (Nx Ny were full tile size!)
+        chunks=(128,256,256) #the previous default was 1 x Nx x Ny (Nx Ny were full tile size!)
     output:
         bdv_n5=temp(
             directory(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -260,7 +260,7 @@ def get_stains(wildcards):
 # bigstitcher
 def get_fiji_launcher_cmd(wildcards, output, threads, resources):
     launcher_opts_find = "-Xincgc"
-    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads}"
+    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads} -XX:ParallelGCThreads={threads/2} -XX:ConcGCThreads={threads/4}"
     pipe_cmds = []
     pipe_cmds.append("ImageJ-linux64 --dry-run --headless --console")
     pipe_cmds.append(f"sed 's/{launcher_opts_find}/{launcher_opts_replace}'/")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -260,7 +260,7 @@ def get_stains(wildcards):
 # bigstitcher
 def get_fiji_launcher_cmd(wildcards, output, threads, resources):
     launcher_opts_find = "-Xincgc"
-    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads} -XX:ParallelGCThreads={int(threads/2)} -XX:ConcGCThreads={int(threads/4)}"
+    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads}"
     pipe_cmds = []
     pipe_cmds.append("ImageJ-linux64 --dry-run --headless --console")
     pipe_cmds.append(f"sed 's/{launcher_opts_find}/{launcher_opts_replace}'/")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -260,7 +260,7 @@ def get_stains(wildcards):
 # bigstitcher
 def get_fiji_launcher_cmd(wildcards, output, threads, resources):
     launcher_opts_find = "-Xincgc"
-    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads} -XX:ParallelGCThreads={threads/2} -XX:ConcGCThreads={threads/4}"
+    launcher_opts_replace = f"-XX:+UseG1GC -verbose:gc -XX:+PrintGCDateStamps -XX:ActiveProcessorCount={threads} -XX:ParallelGCThreads={int(threads/2)} -XX:ConcGCThreads={int(threads/4)}"
     pipe_cmds = []
     pipe_cmds.append("ImageJ-linux64 --dry-run --headless --console")
     pipe_cmds.append(f"sed 's/{launcher_opts_find}/{launcher_opts_replace}'/")

--- a/workflow/rules/flatfield_corr.smk
+++ b/workflow/rules/flatfield_corr.smk
@@ -78,6 +78,8 @@ rule apply_basic_flatfield_corr:
             stain=get_stains(wildcards),
             allow_missing=True,
         ),
+    params:
+        out_chunks=(1,1,128,256,256) #make this a config option -- setting it here instead of rechunking in zarr2bdv
     output:
         zarr=temp(
             directory(

--- a/workflow/rules/flatfield_corr.smk
+++ b/workflow/rules/flatfield_corr.smk
@@ -79,7 +79,7 @@ rule apply_basic_flatfield_corr:
             allow_missing=True,
         ),
     params:
-        out_chunks=(1,1,128,256,256) #make this a config option -- setting it here instead of rechunking in zarr2bdv
+        out_chunks=config["ome_zarr"]["rechunk_size"],
     output:
         zarr=temp(
             directory(

--- a/workflow/rules/ome_zarr.smk
+++ b/workflow/rules/ome_zarr.smk
@@ -77,10 +77,10 @@ rule tif_stacks_to_ome_zarr:
         config["containers"]["spimprep"]
     group:
         "preproc"
-    threads: 8
+    threads: config["cores_per_rule"]
     resources:
         runtime=360,
-        mem_mb=32000,
+        mem_mb=35000,
     script:
         "../scripts/tif_stacks_to_ome_zarr.py"
 

--- a/workflow/rules/ome_zarr.smk
+++ b/workflow/rules/ome_zarr.smk
@@ -80,7 +80,7 @@ rule tif_stacks_to_ome_zarr:
     threads: config["cores_per_rule"]
     resources:
         runtime=360,
-        mem_mb=35000,
+        mem_mb=32000,
     script:
         "../scripts/tif_stacks_to_ome_zarr.py"
 

--- a/workflow/scripts/apply_basic_flatfield_corr_zarr.py
+++ b/workflow/scripts/apply_basic_flatfield_corr_zarr.py
@@ -47,7 +47,7 @@ for i_channel,model in enumerate(snakemake.input.model_dirs):
     chan_arr_list.append(arr_corr)
 
 #stack along chans
-arr_stacked = da.stack(chan_arr_list,axis=1).rechunk(snakemake.params.out_chunks)
+arr_stacked = da.stack(chan_arr_list,axis=1).rechunk([1,1] + snakemake.params.out_chunks)
 
 with ProgressBar():
     da.to_zarr(arr_stacked,snakemake.output.zarr,overwrite=True,dimension_separator='/')

--- a/workflow/scripts/apply_basic_flatfield_corr_zarr.py
+++ b/workflow/scripts/apply_basic_flatfield_corr_zarr.py
@@ -47,7 +47,7 @@ for i_channel,model in enumerate(snakemake.input.model_dirs):
     chan_arr_list.append(arr_corr)
 
 #stack along chans
-arr_stacked = da.stack(chan_arr_list,axis=1)
+arr_stacked = da.stack(chan_arr_list,axis=1).rechunk(snakemake.params.out_chunks)
 
 with ProgressBar():
     da.to_zarr(arr_stacked,snakemake.output.zarr,overwrite=True,dimension_separator='/')

--- a/workflow/scripts/ome_zarr_to_nii.py
+++ b/workflow/scripts/ome_zarr_to_nii.py
@@ -9,7 +9,6 @@ from upath import UPath as Path
 from lib.cloud_io import get_fsspec, is_remote
 
 uri = snakemake.params.uri
-
 in_zarr = snakemake.input.zarr
 channel_index = snakemake.params.channel_index
 
@@ -38,8 +37,11 @@ affine[0,0]=-transforms[0]['scale'][3] #x
 affine[1,1]=-transforms[0]['scale'][2] #y
 affine[2,2]=-transforms[0]['scale'][1] #z
 
-#grab the channel index corresponding to the stain
-darr = da.from_zarr(store,component=f'/{level}')[channel_index,:,:,:].squeeze()
+if is_remote(uri):
+    #grab the channel index corresponding to the stain
+    darr = da.from_zarr(store,component=f'/{level}')[channel_index,:,:,:].squeeze()
+else:
+    darr = da.from_zarr(in_zarr,component=f'/{level}')[channel_index,:,:,:].squeeze()
 
 #input array axes are ZYX 
 #writing to nifti we want XYZ

--- a/workflow/scripts/zarr_to_n5_bdv.py
+++ b/workflow/scripts/zarr_to_n5_bdv.py
@@ -99,7 +99,7 @@ for setup_i,((chan_i,chan),(tile_i,tile)) in enumerate(product(enumerate(metadat
     ds_list=[] #for setup-level attrs
     for ds in range(max_downsampling_layers):
         step=2**ds  #1,2,4,8.. 
-        zstack = da.squeeze(darr[tile_i,chan_i,:,::step,::step]).rechunk(snakemake.params.chunks).astype(np.int16)
+        zstack = da.squeeze(darr[tile_i,chan_i,:,::step,::step]).astype(np.int16)
         print(f'writing to setup{setup_i}/timepoint0/s{ds}')
         with ProgressBar():
             zstack.to_zarr(n5_store,component=f'setup{setup_i}/timepoint0/s{ds}',overwrite=True,compute=True) 

--- a/workflow/scripts/zarr_to_n5_bdv.py
+++ b/workflow/scripts/zarr_to_n5_bdv.py
@@ -34,7 +34,7 @@ in_zarr = snakemake.input.zarr
 max_downsampling_layers=snakemake.params.max_downsampling_layers
 
 #load data  (tiles,chans,zslices,x,y)
-darr = da.from_zarr(in_zarr)
+darr = da.from_zarr(in_zarr,chunks=snakemake.params.chunks).astype(np.int16)
 
 (n_tiles,n_chans,n_z,n_x,n_y) = darr.shape
 
@@ -52,7 +52,7 @@ bdv_writer = npy2bdv.BdvWriter(snakemake.params.temp_h5,
                                 overwrite=True,
                                 nchannels=len(metadata['channels']), 
                                 ntiles=len(metadata['tiles_x'])*len(metadata['tiles_y']),
-                                blockdim=((1,256,256),))
+                                blockdim=(snakemake.params.chunks[2:]))
 
 bdv_writer.set_attribute_labels('channel', metadata['channels'])
 
@@ -110,6 +110,6 @@ for setup_i,((chan_i,chan),(tile_i,tile)) in enumerate(product(enumerate(metadat
     #add attributes for downsampling as a list, and datatype to the setup# level
     g = zarr.open_group(store=n5_store,path=f'setup{setup_i}',mode='r+')
     g.attrs['downsamplingFactors']=ds_list
-    g.attrs['dataType']='uint16'
+    g.attrs['dataType']='int16'
 
 

--- a/workflow/scripts/zarr_to_n5_bdv.py
+++ b/workflow/scripts/zarr_to_n5_bdv.py
@@ -111,6 +111,6 @@ for setup_i,((chan_i,chan),(tile_i,tile)) in enumerate(product(enumerate(metadat
     #add attributes for downsampling as a list, and datatype to the setup# level
     g = zarr.open_group(store=n5_store,path=f'setup{setup_i}',mode='r+')
     g.attrs['downsamplingFactors']=ds_list
-    g.attrs['dataType']='int16'
+    g.attrs['dataType']='uint16'
 
 

--- a/workflow/scripts/zarr_to_ome_zarr.py
+++ b/workflow/scripts/zarr_to_ome_zarr.py
@@ -53,7 +53,7 @@ if is_remote(uri):
     fs = get_fsspec(uri,**fs_args)
     store = zarr.storage.FSStore(Path(uri).path,fs=fs,dimension_separator='/',mode='w')
 else:
-    store = zarr.DirectoryStore(out_zarr) 
+    store = zarr.DirectoryStore(out_zarr,dimension_separator='/') 
 
 
 

--- a/workflow/scripts/zarr_to_ome_zarr.py
+++ b/workflow/scripts/zarr_to_ome_zarr.py
@@ -68,6 +68,7 @@ for zarr_i in range(len(snakemake.input.zarr)):
 
     darr_list.append(da.from_zarr(in_zarr,component=f'{group_name}/s0',chunks=rechunk_size))
 
+
     #append to omero metadata
     channel_metadata={key:val for key,val in snakemake.config['ome_zarr']['omero_metadata']['channels']['defaults'].items()}
     channel_name=stains[zarr_i]


### PR DESCRIPTION
This PR makes changes to the default chunking, to fix issues happening with bigstitcher and fusion where too many threads and too large chunks were causing memory and garbage collection issues that were stalling the run.. 

Problem is likely because we had large-ish 2d chunks, but the processing was requiring 3d context, so ultimately too much memory was being allocated when tryibng to load the 3d data.. 

This also makes some fixes/updates to the tif stack to zarr 