### PR TITLE
dask distributed was still being used for some reason

### DIFF
--- a/workflow/rules/ome_zarr.smk
+++ b/workflow/rules/ome_zarr.smk
@@ -83,7 +83,7 @@ rule tif_stacks_to_ome_zarr:
         "preproc"
     threads: config["total_cores"]
     resources:
-        runtime=360,
+        runtime=720,
         mem_mb=config["total_mem_mb"],
     script:
         "../scripts/tif_stacks_to_ome_zarr.py"

--- a/workflow/scripts/tif_stacks_to_ome_zarr.py
+++ b/workflow/scripts/tif_stacks_to_ome_zarr.py
@@ -8,7 +8,7 @@ from ome_zarr.format import format_from_version
 from ome_zarr.scale import Scaler
 from upath import UPath as Path
 from lib.cloud_io import get_fsspec, is_remote
-from dask.distributed import Client, LocalCluster
+from dask.diagnostics import ProgressBar
 
 in_tif_glob = snakemake.params.in_tif_glob
 metadata_json=snakemake.input.metadata_json
@@ -20,9 +20,6 @@ stains=snakemake.params.stains
 scaling_method=snakemake.params.scaling_method
 uri = snakemake.params.uri
 
-cluster = LocalCluster(processes=False)
-client = Client(cluster)
-print(client.dashboard_link)
 
 # prepare metadata for ome-zarr
 with open(metadata_json) as fp:
@@ -86,12 +83,12 @@ else:
 group = zarr.group(store,overwrite=True)
 scaler = Scaler(max_layer=max_layer,method=scaling_method)
 
-delayed = write_image(image=darr_channels,
+with ProgressBar():
+    write_image(image=darr_channels,
                             group=group,
                             scaler=scaler,
                             coordinate_transformations=coordinate_transformations,
                             axes=axes,
                             metadata={'omero':omero},
-                            compute=True
                                 )
 


### PR DESCRIPTION
was failing because of this, and creating zipfiles with only zarr metadata